### PR TITLE
GGRC-2265,3163 Add "Inherit Assessment Procedure from mapped object" checkbox

### DIFF
--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -25,14 +25,13 @@
           </dropdown>
         </assessment-object-type-dropdown>
 
-        {{#if_equals instance.template_object_type 'Control'}}
         <label class="inline-check pull-left">
           <input type="checkbox"
             can-value="instance.test_plan_procedure"
             class="js-toggle-controlplans">
-          Use control test plans as assessment test plan
+	  Inherit Assessment Procedure from mapped object
         </label>
-        {{/if_equals}}
+
       </div>
     </div>
 

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -25,12 +25,13 @@
       {{/if}}
 
       <div class="ggrc-form-item">
-        <div class="ggrc-form-item__multiple-row">
+        <div class="ggrc-form-item__row">
           <label class="form-label required-label">
             Assessment Type
             <i class="fa fa-asterisk"></i>
           </label>
           <assessment-object-type-dropdown
+            class="input-medium pull-left"
             {instance}="instance"
             {(assessment-type)}="instance.assessment_type">
             <dropdown
@@ -39,6 +40,10 @@
               name="assessmentType">
             </dropdown>
           </assessment-object-type-dropdown>
+          <label class="inline-check pull-left">
+            <input type="checkbox" can-value="instance.test_plan_procedure" class="js-toggle-controlplans">
+              Inherit Assessment Procedure from mapped object
+          </label>
         </div>
       </div>
       <div class="ggrc-form-item">


### PR DESCRIPTION
Switch 'Inherit Assessment Procedure from mapped object' should be added on:
Add / Edit Assessment pop-up.
Add / Edit Assessment Template pop-up.
